### PR TITLE
Adhoc couchbase lite client

### DIFF
--- a/common/main/cpp/native_c4replicator.cc
+++ b/common/main/cpp/native_c4replicator.cc
@@ -184,7 +184,7 @@ bool litecore::jni::initC4Replicator(JNIEnv *env) {
 
 static jobject toJavaObject(JNIEnv *env, C4ReplicatorStatus status) {
     jobject obj = env->NewObject(cls_C4ReplStatus, m_C4ReplStatus_init);
-    env->SetIntField(obj, f_C4ReplStatus_activityLevel, (int) status.level);
+    env->SetIntField(obj, f_C4ReplStatus_activityLevel, (int) (status.level == kC4Stopping ? kC4Stopped : status.level));
     env->SetLongField(obj, f_C4ReplStatus_progressUnitsCompleted, (jlong) status.progress.unitsCompleted);
     env->SetLongField(obj, f_C4ReplStatus_progressUnitsTotal, (jlong) status.progress.unitsTotal);
     env->SetLongField(obj, f_C4ReplStatus_progressDocumentCount, (jlong) status.progress.documentCount);

--- a/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
@@ -209,6 +209,8 @@ public class AbstractCBLWebSocket extends C4Socket {
         .connectTimeout(0, TimeUnit.SECONDS)
         .readTimeout(0, TimeUnit.SECONDS)
         .writeTimeout(0, TimeUnit.SECONDS)
+        .pingInterval(10, TimeUnit.SECONDS)
+        .retryOnConnectionFailure(false)
         // redirection
         .followRedirects(true)
         .followSslRedirects(true)


### PR DESCRIPTION
以下对代码的解读有助于理解这个改动

## SocketFactory 结构体
C/c++ 代码中有个 SocketFactory 结构体 ，提供底层传输信道，可以理解成一个 socket。它的接口是 open、write、read、close 这些指向函数的指针，类比 socket 的 open send recv close。
它有两种模式，framing vs non-framing。framing 模式中，可以理解成调用接口的单位是 message，也就是说底层已经做过消息分割了。
Non-framing 模式中，接口调用的单位是 bytes ，上层还要额外做消息分割。

## WebSocketImpl 类
C/c++ 的 WebSocketImpl 类，组合了一个 SocketFactory。这个类对 framing 和 non-framing 的 SocketFactory 的处理是不同的。
至少有一个差别，在 framing 模式下，WebSocketImpl 才会发送/接受 heartbeat。
在 android 里，SocketFactory 是借助 jni 用 okhttp 实现的，它是 non-framing 模式，上层没有 heartbeat。这是导致发现断网延迟的一个原因。

## heartbeat 应该在 SocketFactory 层实现
按照这个划分，java 实现的 SocketFactory 提供链接/维护信道，上层 WebSocketImpl 实现具体协议逻辑，那么 websocket 的 ping/pong 机制属于信道维护，应该放到 java 代码里做来做。

## SocketFactory 遇到网络错误不应该重试
在网络断连之后，上层应该能够尽快作出反应。如果 SocketFactory 信道层重试时间过长，会推迟应用层得到这个信息的时间。
所以，如果信道层能够控制重试所用的总时间（综合来说，控制重试策略、重试次数等），那么应用层允许信道层重试。
但是如果一重试起来就没完，那么应用层最好取消这个重试，用应用层自己的策略处理网络连接失败。