### PR TITLE
Try to fix long-lasting connecting or busy state

### DIFF
--- a/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
@@ -206,9 +206,9 @@ public class AbstractCBLWebSocket extends C4Socket {
     @NonNull
     private static final OkHttpClient BASE_HTTP_CLIENT = new OkHttpClient.Builder()
         // timeouts: Core manages this: set no timeout, here.
-        .connectTimeout(0, TimeUnit.SECONDS)
-        .readTimeout(0, TimeUnit.SECONDS)
-        .writeTimeout(0, TimeUnit.SECONDS)
+        .connectTimeout(16, TimeUnit.SECONDS)
+        .readTimeout(21, TimeUnit.SECONDS)
+        .writeTimeout(21, TimeUnit.SECONDS)
         .pingInterval(10, TimeUnit.SECONDS)
         .retryOnConnectionFailure(false)
         // redirection

--- a/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
+++ b/common/main/java/com/couchbase/lite/internal/replicator/AbstractCBLWebSocket.java
@@ -94,10 +94,6 @@ public class AbstractCBLWebSocket extends C4Socket {
             return old;
         }
 
-        synchronized void set(short set) { status = set; }
-
-        synchronized short get() { return status; }
-
         synchronized short compareAndSet(short expect, short update) {
             short old = status;
             if (status == expect) {
@@ -294,7 +290,7 @@ public class AbstractCBLWebSocket extends C4Socket {
     //-------------------------------------------------------------------------
 
     private final AtomicBoolean closing = new AtomicBoolean(false);
-    public Status status = new Status();
+    private final Status status = new Status();
     private final OkHttpClient httpClient;
     private final CBLWebSocketListener wsListener;
     private final URI uri;
@@ -361,7 +357,7 @@ public class AbstractCBLWebSocket extends C4Socket {
     @Override
     protected void requestClose(int status, String message) {
         if (webSocket == null) {
-            Log.w(TAG, "CBLWebSocket was not started before receiving close request.");
+            Log.w(TAG, "CBLWebSocket was not initialized before receiving close request.");
             return;
         }
 
@@ -371,7 +367,7 @@ public class AbstractCBLWebSocket extends C4Socket {
         }
 
         if (this.status.getAndSet(Status.REQUEST_CLOSED) == Status.INITIAL) {
-            Log.w(TAG, "CBLWebSocket was not initialized before receiving close request.");
+            Log.w(TAG, "CBLWebSocket connection was not established before receiving close request.");
             webSocket.cancel();
             return;
         }


### PR DESCRIPTION
This is a problem about websocket connection timeout control.

Couchbase replicator connection timeout is designed to be controlled in couchbase core (written with C++, which is set to 15s by default). Thus, in java scope websocket timeouts (including connection, read & write timeout) are explicitly set to 0, which means using os default and may last forever. 

(To reproduce this issue, just simulate a connection error that can only be detected by timeout. For example, block outward connections with firewall to drop SYN packets quietly.)

When a timeout is detected by core, it should call into java scope to stop the attempt to connect (websocket connection not established yet). But that is not the case. The connecting websocket would not be canceled and have resources released.

This patch fix it in some way.
